### PR TITLE
Add report option to show the npm audit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ npm install -g npm-audit-ci
 ```
 › npm-audit-ci --help                    
 Options:
-  --version        Show version number                                 [boolean]
-  -l, --low        Exit even for low vulnerabilities  [boolean] [default: false]
-  -m, --moderate   Exit only when moderate or above vulnerabilities
+  --version       Show version number                                  [boolean]
+  -l, --low       Exit even for low vulnerabilities   [boolean] [default: false]
+  -m, --moderate  Exit only when moderate or above vulnerabilities
                                                       [boolean] [default: false]
-  -h, --high       Exit only when high or above vulnerabilities
+  -h, --high      Exit only when high or above vulnerabilities
                                                       [boolean] [default: false]
   -c, --critical  Exit only for critical vulnerabilities
                                                        [boolean] [default: true]
-  --help           Show help
+  -r, --report    Show npm audit report               [boolean] [default: false]
+  --help          Show help                                            [boolean]
 ```
 
 License

--- a/index.js
+++ b/index.js
@@ -27,6 +27,12 @@ var argv = require('yargs')
         default: true,
         describe: 'Exit only for critical vulnerabilities',
         type: 'boolean'
+      },
+      'r': {
+        alias: 'report',
+        default: false,
+        describe: 'Show npm audit report',
+        type: 'boolean'
       }
     })
     .help('help')
@@ -68,6 +74,10 @@ const run = () =>{
         return console.log('No issues :: SUCCESS');
       }
       
+      if (argv.report) {
+        console.log(stdout);
+      }
+
       var logArr = stdout.split('\n').filter(line => line);
       var severityline = logArr[logArr.length - 1];
       var severityType = parseMessage(severityline, argv);
@@ -76,12 +86,21 @@ const run = () =>{
         case 'HIGH':
         case 'MODERATE':
         case 'LOW':
-          console.log(`FAILURE :: ${severityType} :: ${severityline}`);
+          let message = `FAILURE :: ${severityType}`;
+
+          if (!argv.report) {
+            message = `${message} :: ${severityline}`;
+          }
+
+          console.log(message);
           process.exit(1);
           return;
         case '':      
         default:
-          console.log(severityline);
+          if (!argv.report) {
+            console.log(severityline);
+          }
+
           return;
       }
     }


### PR DESCRIPTION
Hi,

It would be great to see the original npm audit report and recommendations on the CI environment so I added a `-r` option to show the original npm audit report.

I tried to keep the output consistent with what you had before but please consider my pull request and if needed I can adapt or address any issue you point out.

Thanks,