### PR TITLE
Set stdout buffer size to 10MB

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@ const run = () =>{
     auditCommand += ` --registry ${argv.registry}`;
   }
 
-  exec(auditCommand, function (error, stdout, stderr) {
+  const execOptions = { maxBuffer: 10 * 1024 * 1024 };
+
+  exec(auditCommand, execOptions, function (error, stdout, stderr) {
     if (stdout) {
      
       if (argv.report) {

--- a/index.js
+++ b/index.js
@@ -88,6 +88,11 @@ const run = () =>{
   const execOptions = { maxBuffer: 10 * 1024 * 1024 };
 
   exec(auditCommand, execOptions, function (error, stdout, stderr) {
+    if (error !== null) {
+      console.log('exec error: ' + error);
+      return;
+    }
+
     if (stdout) {
      
       if (argv.report) {
@@ -119,9 +124,6 @@ const run = () =>{
 
           return;
       }
-    }
-    if (error !== null) {
-      console.log('exec error: ' + error);
     }
   });
 };


### PR DESCRIPTION
When I run npm-audit-in project whose output of `npm audit --json` is too big (in my case, 6.1MB), it fails because stdout is being trimmed:

```
> npm-audit-ci -c "report"

undefined:4457
          "dev": tru

SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at /Users/esdras/dev/project/node_modules/npm-audit-ci/index.js:93:31
    at ChildProcess.exithandler (child_process.js:301:5)
    at ChildProcess.emit (events.js:189:13)
    at maybeClose (internal/child_process.js:970:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
```

I couldn't think of a better solution, but I increased the max buffer size to 10MB to prevent this issue.

Extra notes about buffer size: https://nodejs.org/api/child_process.html#child_process_maxbuffer_and_unicode